### PR TITLE
More flags for metrics, to allow easier skipping

### DIFF
--- a/lib/Module/CPANTS/Kwalitee/Distname.pm
+++ b/lib/Module/CPANTS/Kwalitee/Distname.pm
@@ -56,12 +56,14 @@ sub kwalitee_indicators {
             name=>'has_version',
             error=>"The package filename (eg. Foo-Bar-1.42.tar.gz) does not include a version number (or something that looks like a reasonable version number to CPAN::DistnameInfo)",
             remedy=>q{Add a version number to the packed distribution. Or use a buildtool ('make dist' or 'Build dist')},
+            needs_tarball=>1,
             code=>sub { shift->{version} ? 1 : 0 }
         },
         {
             name=>'has_proper_version',
             error=>"The version number isn't a number. It probably contains letter besides a leading 'v', which it shouldn't",
             remedy=>q{Remove all letters from the version number. If you want to mark a release as a developer release, use the scheme 'Module-1.00_01'},
+            needs_tarball=>1,
             code=>sub { my $v=shift->{version};
                  return 0 unless $v;
                  return 1 if ($v=~ /\A v? \d+ (?:\.\d+)* (?:_\d+)? (\-TRIAL)?\z/xi );

--- a/lib/Module/CPANTS/Kwalitee/Files.pm
+++ b/lib/Module/CPANTS/Kwalitee/Files.pm
@@ -277,6 +277,7 @@ sub kwalitee_indicators {
         name=>'no_generated_files',
         error=>q{This distribution has a file that should be generated at build time, not distributed by the author.},
         remedy=>q{Remove the offending file!},
+        no_build=>1,
         code=>sub {
             my $d=shift;
             #die Dumper \%generated_db_files;

--- a/lib/Module/CPANTS/Kwalitee/Files.pm
+++ b/lib/Module/CPANTS/Kwalitee/Files.pm
@@ -184,12 +184,14 @@ sub kwalitee_indicators {
         name=>'extractable',
         error=>q{This package uses an unknown packaging format. CPANTS can handle tar.gz, tgz and zip archives. No kwalitee metrics have been calculated.},
         remedy=>q{Pack the distribution with tar & gzip or zip.},
+        needs_tarball=>1,
         code=>sub { shift->{extractable} ? 1 : -100 },
     },
     {
         name=>'extracts_nicely',
         error=>q{This package doesn't create a directory and extracts its content into this directory. Instead, it spews its content into the current directory, making it really hard/annoying to remove the unpacked package.},
         remedy=>q{Issue the command to pack the distribution in the directory above it. Or use a buildtool ('make dist' or 'Build dist')},
+        needs_tarball=>1,
         code=>sub { shift->{extracts_nicely} ? 1 : 0},
     },
     {

--- a/lib/Module/CPANTS/Kwalitee/Files.pm
+++ b/lib/Module/CPANTS/Kwalitee/Files.pm
@@ -215,7 +215,7 @@ sub kwalitee_indicators {
     {
         name=>'has_buildtool',
         error=>q{Makefile.PL and/or Build.PL are missing. This makes installing this distribution hard for humans and impossible for automated tools like CPAN/CPANPLUS},
-        remedy=>q{Use a buildtool like Module::Build (recomended) or ExtUtils::MakeMaker to manage your distribution},
+        remedy=>q{Use a buildtool like Module::Build (recommended) or ExtUtils::MakeMaker to manage your distribution},
         code=>sub {
             my $d=shift;
             return 1 if $d->{file_makefile_pl} || $d->{file_build_pl};

--- a/lib/Module/CPANTS/Kwalitee/Manifest.pm
+++ b/lib/Module/CPANTS/Kwalitee/Manifest.pm
@@ -72,6 +72,7 @@ sub kwalitee_indicators {
             name=>'manifest_matches_dist',
             error=>q{MANIFEST does not match the contents of this distribution. See 'error_manifest_matches_dist' in the dist view for more info.},
             remedy=>q{Use a buildtool to generate the MANIFEST. Or update MANIFEST manually.},
+            needs_tarball=>1,
             code=>sub { shift->{manifest_matches_dist} ? 1 : 0 },
         }
     ];


### PR DESCRIPTION
Test::Kwalitee 1.09 now tests all the 'standard' (not extra, experimental) that Module::CPANTS::Analyse makes available, except for these tests: no_generated_files, extractable, extracts_nicely, has_proper_version, has_version, manifest_matches_dist.

The first of these (no_generated_files) cannot be run after a 'make' or './Build', as we will get false positives from the files that were generated.

The rest all need a dist.tar.gz to be present, to compare against.

It would be easier to be able to skip these tests by using flags, rather than having to hardcode the names themselves (so as to give you more flexibility in the future to add more metrics).
