### PR TITLE
Start a YAML.JSON module

### DIFF
--- a/lib/Module/CPANTS/Analyse.pm
+++ b/lib/Module/CPANTS/Analyse.pm
@@ -11,7 +11,6 @@ use Carp;
 use Module::CPANTS::Kwalitee;
 use IO::Capture::Stdout;
 use IO::Capture::Stderr;
-use YAML::Any qw(LoadFile);
 
 our $VERSION = '0.87';
 
@@ -212,10 +211,6 @@ Returns the location of the unextracted tarball.
 =head3 tarball
 
 Returns the filename of the tarball.
-
-=head3 read_meta_yml
-
-Reads the META.yml file and returns its content.
 
 =head1 WEBSITE
 

--- a/lib/Module/CPANTS/Kwalitee/Files.pm
+++ b/lib/Module/CPANTS/Kwalitee/Files.pm
@@ -211,6 +211,13 @@ sub kwalitee_indicators {
         code=>sub { shift->{file_meta_yml} ? 1 : 0 },
     },
     {
+        is_experimental=>1,
+        name=>'has_meta_json',
+        error=>q{The file 'META.json' is missing from this distribution. META.json is needed by people maintaining module collections (like CPAN), for people writing installation tools, or just people who want to know some stuff about a distribution before downloading it.},
+        remedy=>q{Add a META.json to the distribution. Your buildtool should be able to autogenerate it.},
+        code=>sub { shift->{file_meta_json} ? 1 : 0 },
+    },
+    {
         name=>'has_buildtool',
         error=>q{Makefile.PL and/or Build.PL are missing. This makes installing this distribution hard for humans and impossible for automated tools like CPAN/CPANPLUS},
         remedy=>q{Use a buildtool like Module::Build (recomended) or ExtUtils::MakeMaker to manage your distribution},

--- a/t/02_kwalitee.t
+++ b/t/02_kwalitee.t
@@ -8,7 +8,7 @@ use Module::CPANTS::Kwalitee;
 
 my $CORE = 26;
 my $EXTRA = 8; #is_extra set
-my $EXPERIMENTAL = 10; #experimental?
+my $EXPERIMENTAL = 12; #experimental?
 my $METRICS = $CORE + $EXTRA + $EXPERIMENTAL;
 
 plan tests => 8 + 2 * $METRICS;

--- a/t/03_plugins.t
+++ b/t/03_plugins.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 9;
+use Test::More tests => 10;
 use Test::Deep;
 use Test::NoWarnings;
 
@@ -15,7 +15,7 @@ my $a=Module::CPANTS::Analyse->new({dist => 'dummy'});
 
 {
 	my @plugins=$a->plugins;
-	is(@plugins,16,'number of plugins');
+	is(@plugins,17,'number of plugins');
 }
 
 
@@ -24,7 +24,8 @@ my $plugins=$a->mck->generators;
 is(shift(@$plugins),'Module::CPANTS::Kwalitee::Files','plugin order 1 Files');
 is(shift(@$plugins),'Module::CPANTS::Kwalitee::Distname','plugin order 2 Distname');
 is(shift(@$plugins),'Module::CPANTS::Kwalitee::MetaYML','plugin order 3 MetaYML');
-is(shift(@$plugins),'Module::CPANTS::Kwalitee::FindModules','plugin order 4 FindModules');
+is(shift(@$plugins),'Module::CPANTS::Kwalitee::MetaJSON','plugin order 4 MetaJSON');
+is(shift(@$plugins),'Module::CPANTS::Kwalitee::FindModules','plugin order 5 FindModules');
 is(pop(@$plugins),'Module::CPANTS::Kwalitee::CpantsErrors','plugin order last CpantsErrors');
 
 cmp_deeply($plugins,bag(

--- a/t/10_analyse.t
+++ b/t/10_analyse.t
@@ -80,6 +80,7 @@ my @tests = (
            'has_changelog' => 1,
            'no_pod_errors' => 1,
            'use_strict' => 1,
+           'metajson_is_parsable' => 0,
            'kwalitee' => 29,
            'no_stdin_for_prompting' => 1,
            'easily_repackageable' => 0,
@@ -149,6 +150,7 @@ my @tests = (
            'metayml_declares_perl_version' => 1,
            'has_example' => 1,
            'metayml_is_parsable' => 1,
+           'metajson_is_parsable' => 0,
            'proper_libs' => 1,
            'has_changelog' => 1,
            'no_pod_errors' => 1,
@@ -201,6 +203,7 @@ my @tests = (
            'metayml_declares_perl_version' => 0,
            'has_example' => 1,
            'metayml_is_parsable' => 1,
+           'metajson_is_parsable' => 0,
            'proper_libs' => 1,
            'has_changelog' => 1,
            'no_pod_errors' => 1,
@@ -248,6 +251,7 @@ my @tests = (
            'metayml_declares_perl_version' => 1,
            'has_example' => 0,
            'metayml_is_parsable' => 1,
+           'metajson_is_parsable' => 0,
            'proper_libs' => 1,
            'has_changelog' => 1,
            'no_pod_errors' => 1,
@@ -298,6 +302,7 @@ my @tests = (
            'has_changelog' => 1,
            'no_pod_errors' => 1,
            'use_strict' => 1,
+           'metajson_is_parsable' => 0,
            'kwalitee' => 38,
            'no_stdin_for_prompting' => 1,
            'has_license_in_source_file' => 1,
@@ -340,6 +345,7 @@ my @tests = (
            'metayml_declares_perl_version' => 1,
            'has_example' => 1,
            'metayml_is_parsable' => 1,
+           'metajson_is_parsable' => 0,
            'proper_libs' => 1,
            'has_changelog' => 1,
            'no_pod_errors' => 1,
@@ -396,7 +402,7 @@ foreach my $t (@tests) {
         });
 
     my $rv=$a->unpack;
-    is($rv,undef,'unpack ok');
+    is($rv,undef,"unpack $t->{dist}");
 
     $a->analyse;
     $a->calc_kwalitee;

--- a/t/generated_files.t
+++ b/t/generated_files.t
@@ -45,6 +45,7 @@ my $expected = {
            'has_humanreadable_license' => 0,
            'no_generated_files' => 0,
            'has_meta_yml' => 1,
+           'has_meta_json' => 0,           
            'metayml_conforms_spec_current' => 0,
            'use_warnings' => 0,
            'no_large_files' => 1,


### PR DESCRIPTION
For now defines `metajson_is_parsable` and `has_meta_json`

The main reason for start doing this is to use module requiremenets listed as spec 2.0 version.
If this gets accepted, will try to do that next step.
Best,
ambs
